### PR TITLE
[Ref] remove MCPL_input_once registry insertion

### DIFF
--- a/src/restage/instr.py
+++ b/src/restage/instr.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Union
 from mccode_antlr.instr import Instr
-from mccode_antlr.reader import Registry
 
 
-def load_instr(filepath: Union[str, Path], extra_registries: list[Registry] | None = None) -> Instr:
+def load_instr(filepath: Union[str, Path]) -> Instr:
     """Loads an Instr object from a .instr file or a HDF5 file"""
     from mccode_antlr.io import load_hdf5
     from mccode_antlr.loader import load_mcstas_instr
@@ -19,23 +18,10 @@ def load_instr(filepath: Union[str, Path], extra_registries: list[Registry] | No
     if not filepath.exists() or not filepath.is_file():
         raise ValueError('The provided filepath does not exist or is not a file')
 
-    # FIXME this hack should be removed ASAP
-    if extra_registries is None:
-        from mccode_antlr.reader import GitHubRegistry
-        mcpl_input_once_registry = GitHubRegistry(
-            name='mcpl_input_once',
-            url='https://github.com/g5t/mccode-mcpl-input-once',
-            version='main',
-            filename='pooch-registry.txt'
-        )
-        extra_registries = [mcpl_input_once_registry]
-
     if filepath.suffix == '.instr':
-        return load_mcstas_instr(filepath, registries=extra_registries)
+        return load_mcstas_instr(filepath)
 
-    instr = load_hdf5(filepath)
-    instr.registries += tuple(extra_registries)
-    return instr
+    return load_hdf5(filepath)
 
 
 def collect_parameter_dict(instr: Instr, kwargs: dict, strict: bool = True) -> dict:
@@ -60,7 +46,7 @@ def collect_parameter_dict(instr: Instr, kwargs: dict, strict: bool = True) -> d
     for k, v in kwargs.items():
         if k not in parameters:
             if strict:
-                raise ValueError(f"Parameter {k} is not a valid parameter name")
+                raise ValueError(f"Parameter {k} is not a valid parameter name. Valid names are: {', '.join(parameters)}")
             continue
         if not isinstance(v, Value):
             expected_type = parameters[k].data_type


### PR DESCRIPTION
With `MCPL_input_once` in the main branch of the repository for McCode, the insertion technique is no longer needed.