### PR TITLE
[Fix] chopper parameter names

### DIFF
--- a/src/restage/bifrost_choppers.py
+++ b/src/restage/bifrost_choppers.py
@@ -82,9 +82,7 @@ def bandwidth_chopper_speeds_phases(energy_minimum: float):
     return SOURCE_FREQUENCY, phase, -SOURCE_FREQUENCY, phase
 
 
-def calculate(order: float, time: float, energy: float, names: list[str] | None = None):
-    if names is None or len(names) != 6:
-        names = ['ps1', 'ps2', 'fo1', 'fo2', 'bw1', 'bw2']
+def calculate(order: float, time: float, energy: float, names: tuple[str, ...]):
     a, b, c, d, e, f = names
     s, p = 'speed', 'phase'
     r = dict()
@@ -94,9 +92,12 @@ def calculate(order: float, time: float, energy: float, names: list[str] | None 
     return r
 
 
-def main(order: float, time: float, energy: float, names: list[str] | None = None):
+def main(order: float, time: float, energy: float, names: tuple[str, ...] | None = None):
     if names is None or len(names) != 6:
-        names = ['ps1', 'ps2', 'fo1', 'fo2', 'bw1', 'bw2']
+        # names = ('ps1', 'ps2', 'fo1', 'fo2', 'bw1', 'bw2')
+        names = ('pulse_shaping_chopper_1', 'pulse_shaping_chopper_2',
+                 'frame_overlap_chopper_1', 'frame_overlap_chopper_2',
+                 'bandwidth_chopper_1', 'bandwidth_chopper_2')
     rep = calculate(order, time, energy, names)
     print(' '.join([f'{k}={v}' for k, v in rep.items()]))
 

--- a/src/restage/cache.py
+++ b/src/restage/cache.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from mccode_antlr.instr import Instr
 from .tables import InstrEntry, SimulationTableEntry, SimulationEntry
-from mccode_antlr.compiler.c import CBinaryTarget
 
 
 def setup_database(named: str):
@@ -54,6 +53,8 @@ def _compile_instr(entry: InstrEntry, instr: Instr, config: dict | None = None,
         generator = MCSTAS_GENERATOR
 
     output = directory_under_module_data_path('bin')
+    # TODO consider adding `dump_source=True` _and_ putting the resulting file into
+    #      the cache in order to make debugging future problems a tiny bit easier.
     binary_path = compile_instrument(instr, target, output, generator=generator, config=config)
     entry.mccode_version = __version__
     entry.binary_path = str(binary_path)

--- a/src/restage/energy.py
+++ b/src/restage/energy.py
@@ -10,13 +10,15 @@ def get_and_remove(d: dict, k: str, default=None):
     return default
 
 
-def one_generic_energy_to_chopper_parameters(calculate_choppers, time: float, order: int, parameters: dict):
+def one_generic_energy_to_chopper_parameters(
+        calculate_choppers, chopper_names: tuple[str, ...],
+        time: float, order: int, parameters: dict):
     if any(x in parameters for x in ('ei', 'wavelength', 'lambda', 'energy', 'e')):
         ei = get_and_remove(parameters, 'ei', get_and_remove(parameters, 'energy', get_and_remove(parameters, 'e')))
         if ei is None:
             wavelength = get_and_remove(parameters, 'wavelength', get_and_remove(parameters, 'lambda'))
             ei = _wavelength_angstrom_to_energy_mev(wavelength)
-        choppers = calculate_choppers(order, time, ei)
+        choppers = calculate_choppers(order, time, ei, names=chopper_names)
         parameters.update(choppers)
     return parameters
 
@@ -24,25 +26,28 @@ def one_generic_energy_to_chopper_parameters(calculate_choppers, time: float, or
 def bifrost_translate_energy_to_chopper_parameters(parameters: dict):
     from itertools import product
     from .bifrost_choppers import calculate
-    for name in product([a+b for a, b in product(('ps', 'fo', 'bw'), ('1', '2'))], ('speed', 'phase')):
+    choppers = tuple(f'{a}_chopper_{b}' for a, b in product(['pulse_shaping', 'frame_overlap', 'bandwidth'], [1, 2]))
+    # names = [a+b for a, b in product(('ps', 'fo', 'bw'), ('1', '2'))]
+    for name in product(choppers, ('speed', 'phase')):
         name = ''.join(name)
         if name not in parameters:
             parameters[name] = 0
     order = get_and_remove(parameters, 'order', 14)
     time = get_and_remove(parameters, 'time', get_and_remove(parameters, 't', 170/180/(2 * 15 * 14)))
-    return one_generic_energy_to_chopper_parameters(calculate, time, order, parameters)
+    return one_generic_energy_to_chopper_parameters(calculate, choppers, time, order, parameters)
 
 
 def cspec_translate_energy_to_chopper_parameters(parameters: dict):
     from itertools import product
     from .cspec_choppers import calculate
-    for name in product(('bw1', 'bw2', 'bw3', 's', 'p', 'm1', 'm2'), ('speed', 'phase')):
+    choppers = ('bw1', 'bw2', 'bw3', 's', 'p', 'm1', 'm2')
+    for name in product(choppers, ('speed', 'phase')):
         name = ''.join(name)
         if name not in parameters:
             parameters[name] = 0
     time = get_and_remove(parameters, 'time', 0.004)
     order = get_and_remove(parameters, 'order', 16)
-    return one_generic_energy_to_chopper_parameters(calculate, time, order, parameters)
+    return one_generic_energy_to_chopper_parameters(calculate, choppers, time, order, parameters)
 
 
 def no_op_translate_energy_to_chopper_parameters(parameters: dict):

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -218,6 +218,13 @@ class SplitRunTestCase(unittest.TestCase):
             shutil.rmtree(self.dir)
 
     def test_simple_scan(self):
+        """This test requires MCPL shared libraries to work
+
+        For some unexplored reason, MCPL shared libraries are not found in their
+        default installed location, /usr/local/lib64/libmcpl.so; so this test must
+        be invoked with that location specified, e.g.,
+            $ LD_LIBRARY_PATH=/usr/local/lib64 pytest test/test_single.py -k test_simple_scan
+        """
         # Scanning a1 and a2 with a2=2*a1 should produce approximately the same intensity for all points
         # as long as a1 is between the limits of min_a1 and max_a1
         from restage.splitrun import splitrun


### PR DESCRIPTION
Fixes #15 by renaming the chopper parameters in `energy.py` and adding them as a required input parameter to `calculate`.
This should make future changes easier, by only needing to modify one file, and also possibly support making this a runtime-defined list of names.