### PR TITLE
[Add] multiple (read-only) cache databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,35 @@ splitrun my_instrument.instr -n 1000000 -d /data/output sample_angle=1:90 sample
 
 
 
+## Cached data
+### Default writable cache
+A `sqlite3` database is used to keep track of instrument stages, their compiled
+binaries, and output file(s) produced by, e.g., `splitrun` simulations.
+The default database location is determined by `platformdirs` under a folder
+set by `user_cache_path('restage', 'ess')` and the default locations for 
+`restage`-compiled instrument binaries and simulation output is determined from
+`user_data_path('restage', 'ess')`.
+
+### Override the database and output locations
+These default locations can be overridden by setting the `RESTAGE_CACHE` environment
+variable to a writeable folder, e.g., `export RESTAGE_CACHE="/tmp/ephemeral"`.
+
+### Read-only cache database(s)
+Any number of fixed databases can be provided to allow for, e.g., system-wide reuse
+of common staged simulations.
+The location(s) of these database file(s) can be specified as a single
+environment variable containing space-separated file locations, e.g.,
+`export RESTAGE_FIXED="/usr/local/restage /afs/ess.eu/restage"`.
+If the locations provided include a `database.db` file, they will be used to search
+for instrument binaries and simulation output directories.
+
+### Use a configuration file to set parameters
+Cache configuration information can be provided via a configuration file at, 
+e.g., `~/.config/restage/config.yaml`, like
+```yaml
+cache: /tmp/ephemeral
+fixed: /usr/local/restage /afs/ess.eu/restage
+```
+The exact location searched to find the configuration file is platform dependent,
+please consult the [`confuse` documentation](https://confuse.readthedocs.io/en/latest/usage.html)
+for the paths used on your system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "restage"
 dependencies = [
     'zenlog>=1.1',
     'platformdirs>=3.11',
+    'confuse',
     'psutil>=5.9.6',
     'mccode-antlr[hdf5]>=0.10.2',
 ]

--- a/src/restage/__init__.py
+++ b/src/restage/__init__.py
@@ -12,7 +12,6 @@ from .tables import (SimulationEntry,
                      InstrEntry
                      )
 from .database import Database
-from .cache import DATABASE
 
 
 try:
@@ -28,5 +27,4 @@ __all__ = [
     'NexusStructureEntry',
     'InstrEntry',
     'Database',
-    'DATABASE'
 ]

--- a/src/restage/config/__init__.py
+++ b/src/restage/config/__init__.py
@@ -1,0 +1,28 @@
+import confuse
+from os import environ
+# Any platform independent configuration settings can go in 'default.yaml'
+config = confuse.LazyConfig('restage', __name__)
+
+# use environment variables specified as 'RESTAGE_XYZ' as configuration entries 'xyz'
+config.set_env()
+# Expected environment variables:
+#   RESTAGE_FIXED="/loc/one /usr/loc/two"
+#   RESTAGE_CACHE="$HOME/loc/three"
+
+
+def _common_defaults():
+    import yaml
+    from importlib.resources import files, as_file
+
+    common_file = files(__name__).joinpath('default.yaml')
+    if not common_file.is_file():
+        raise RuntimeError(f"Can not locate default.yaml in module files (looking for {common_file})")
+    with as_file(common_file) as file:
+        with open(file, 'r') as data:
+            common_configs = yaml.safe_load(data)
+
+    return common_configs or {}
+
+
+# By using the 'add' method, we set these as the *lowest* priority. Any user/system files will override:
+config.add(_common_defaults())

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -12,8 +12,8 @@ class CacheTestCase(unittest.TestCase):
         self.db_file = self.db_dir.joinpath('test_database.db')
         self.db = Database(self.db_file)
 
-        self.orig_db = restage.cache.DATABASE
-        restage.cache.DATABASE = self.db
+        self.orig_db = restage.cache.FILESYSTEM.db_write
+        restage.cache.FILESYSTEM.db_write = self.db
 
         contents = """DEFINE INSTRUMENT simple_test_instrument(
                     par1, double par2, int par3, par4=1, string par5="string", double par6=6.6
@@ -28,7 +28,7 @@ class CacheTestCase(unittest.TestCase):
 
     def tearDown(self) -> None:
         import restage.cache
-        restage.cache.DATABASE = self.orig_db
+        restage.cache.FILESYSTEM.db_write = self.orig_db
         del self.orig_db
 
         del self.db

--- a/test/test_cache_ro.py
+++ b/test/test_cache_ro.py
@@ -66,9 +66,7 @@ class ROCacheTestCase(unittest.TestCase):
         restage.cache.FILESYSTEM.db_write = self.orig_rw_db
 
         for file in (self.ro_db_file, self.rw_db_file):
-            if file.exists():
-                file.unlink()
-            del file
+            file.unlink(missing_ok=True)
         for directory in (self.ro_dir, self.rw_dir):
             if directory.exists():
                 directory.rmdir()

--- a/test/test_cache_ro.py
+++ b/test/test_cache_ro.py
@@ -1,0 +1,107 @@
+import unittest
+
+"""
+Test the multi-database mechanism by
+    1. creating a temporary database and location for binaries and simulations
+    2. adding at least one instrument and one simulation to the database
+    3. making the first temporary database read-only, adding a second writable one
+    4. 'using' the read-only simulation
+    5. adding a new simulation for the instrument in the read-only database to the
+       second database 
+"""
+
+class ROCacheTestCase(unittest.TestCase):
+    def setUp(self):
+        from pathlib import Path
+        from tempfile import mkdtemp
+        import restage.cache
+        import mccode_antlr
+        from restage.cache import cache_instr, cache_simulation_table, cache_simulation
+        from restage.database import Database
+        from restage.instr import collect_parameter
+        from restage import SimulationEntry
+        from mccode_antlr.loader import parse_mcstas_instr
+        self.ro_dir = Path(mkdtemp())
+        self.ro_db_file = self.ro_dir.joinpath('test_database.db')
+        self.ro_db = Database(self.ro_db_file)
+
+        self.orig_ro_db = restage.cache.FILESYSTEM.db_fixed
+        self.orig_rw_db = restage.cache.FILESYSTEM.db_write
+        restage.cache.FILESYSTEM.db_write = self.ro_db
+
+        contents = """DEFINE INSTRUMENT simple_test_instrument(
+                            par1, double par2, int par3, par4=1, string par5="string", double par6=6.6
+                            )
+                        TRACE
+                        COMPONENT origin = Arm() AT (0, 0, 0) ABSOLUTE
+                        COMPONENT sample = Arm() AT (0, 0, 1) ABSOLUTE
+                        COMPONENT detector = Arm() AT (0, 0, 2) ABSOLUTE
+                        END
+                        """
+        self.instr = parse_mcstas_instr(contents)
+
+        # Set up the 'read-only' part (this functionality checked in CacheTestCase)
+        instr_entry = cache_instr(self.instr, mccode_version=mccode_antlr.__version__, binary_path=self.ro_dir / "bin" / "blah")
+        cache_simulation_table(instr_entry, SimulationEntry(collect_parameter(self.instr)))
+        self.par = collect_parameter(self.instr, par1=1., par2=2., par3=3, par4=4., par5='five', par6=6.)
+        cache_simulation(instr_entry, SimulationEntry(self.par))
+
+        # Close the database file, and re-open it read-only
+        del self.ro_db
+        self.ro_db = Database(self.ro_db_file, readonly=True)
+        restage.cache.FILESYSTEM.db_fixed = (self.ro_db,)
+
+        # Make a new writable database
+        self.rw_dir = Path(mkdtemp())
+        self.rw_db_file = self.rw_dir.joinpath('test_database.db')
+        self.rw_db = Database(self.rw_db_file)
+        restage.cache.FILESYSTEM.db_write = self.rw_db
+
+    def tearDown(self):
+        import restage.cache
+        restage.cache.FILESYSTEM.db_fixed = self.orig_ro_db
+        restage.cache.FILESYSTEM.db_write = self.orig_rw_db
+
+        for file in (self.ro_db_file, self.rw_db_file):
+            if file.exists():
+                file.unlink()
+            del file
+        for directory in (self.ro_dir, self.rw_dir):
+            if directory.exists():
+                directory.rmdir()
+            del directory
+
+    def test_ro_simulation_retrieval(self):
+        from pathlib import Path
+        from restage import SimulationEntry
+        from restage.cache import cache_get_instr, cache_has_simulation, cache_get_simulation
+        instr_entry = cache_get_instr(self.instr)
+        self.assertEqual(Path(instr_entry.binary_path), self.ro_dir / "bin" / "blah")
+        self.assertTrue(cache_has_simulation(instr_entry, SimulationEntry(self.par)))
+        self.assertEqual(len(cache_get_simulation(instr_entry, SimulationEntry(self.par))), 1)
+
+    def test_rw_simulation_insertion(self):
+        from pathlib import Path
+        from restage import SimulationEntry
+        from restage.cache import FILESYSTEM
+        from restage.cache import (
+            cache_get_instr, cache_has_simulation, cache_get_simulation,
+            cache_simulation, cache_simulation_table
+        )
+        from restage.instr import collect_parameter
+        instr_entry = cache_get_instr(self.instr)
+        self.assertEqual(Path(instr_entry.binary_path), self.ro_dir / "bin" / "blah")
+
+        par = collect_parameter(self.instr, par1=2., par2=3., par3=4, par4=5., par5='six', par6=7.)
+        entry = SimulationEntry(par)
+
+        self.assertTrue(cache_has_simulation(instr_entry, SimulationEntry(self.par)))
+        self.assertFalse(cache_has_simulation(instr_entry, entry))
+
+        cache_simulation(instr_entry, entry)
+
+        self.assertEqual(len(cache_get_simulation(instr_entry, entry)), 1)
+
+        table = cache_simulation_table(instr_entry, entry)
+        self.assertEqual(len(FILESYSTEM.db_write.retrieve_simulation(table.id, entry)), 1)
+        self.assertEqual(len(FILESYSTEM.db_fixed[0].retrieve_simulation(table.id, entry)), 0)

--- a/test/test_cache_ro.py
+++ b/test/test_cache_ro.py
@@ -65,6 +65,8 @@ class ROCacheTestCase(unittest.TestCase):
         restage.cache.FILESYSTEM.db_fixed = self.orig_ro_db
         restage.cache.FILESYSTEM.db_write = self.orig_rw_db
 
+        del self.ro_db
+        del self.rw_db
         for file in (self.ro_db_file, self.rw_db_file):
             file.unlink(missing_ok=True)
         for directory in (self.ro_dir, self.rw_dir):

--- a/test/test_cache_ro.py
+++ b/test/test_cache_ro.py
@@ -21,8 +21,11 @@ class ROCacheTestCase(unittest.TestCase):
         from restage.instr import collect_parameter
         from restage import SimulationEntry
         from mccode_antlr.loader import parse_mcstas_instr
+
+        database_name = self.id().split('.')[-1] + '.db'
+
         self.ro_dir = Path(mkdtemp())
-        self.ro_db_file = self.ro_dir.joinpath('test_database.db')
+        self.ro_db_file = self.ro_dir.joinpath('ro_' + database_name)
         self.ro_db = Database(self.ro_db_file)
 
         self.orig_ro_db = restage.cache.FILESYSTEM.db_fixed
@@ -53,7 +56,7 @@ class ROCacheTestCase(unittest.TestCase):
 
         # Make a new writable database
         self.rw_dir = Path(mkdtemp())
-        self.rw_db_file = self.rw_dir.joinpath('test_database.db')
+        self.rw_db_file = self.rw_dir.joinpath('rw_' + database_name)
         self.rw_db = Database(self.rw_db_file)
         restage.cache.FILESYSTEM.db_write = self.rw_db
 

--- a/test/test_env_vars.py
+++ b/test/test_env_vars.py
@@ -1,0 +1,43 @@
+import os
+from unittest import TestCase, mock
+from pathlib import Path
+
+
+def restage_loaded():
+    import sys
+    return 'restage' in sys.modules or 'restage.config' in sys.modules
+
+
+def first(test):
+    import unittest
+    @unittest.skipIf(restage_loaded(), reason="Environment variable patching must be done before restage is loaded")
+    def first_test(*args, **kwargs):
+        return test(*args, **kwargs)
+    return first_test
+
+
+class SettingsTests(TestCase):
+    @first
+    @mock.patch.dict(os.environ, {"RESTAGE_CACHE": "/tmp/some/location"})
+    def test_restage_cache_config(self):
+        from restage.config import config
+        self.assertTrue(config['cache'].exists())
+        self.assertEqual(config['cache'].as_path(), Path('/tmp/some/location'))
+
+    @first
+    @mock.patch.dict(os.environ, {"RESTAGE_FIXED": "/tmp/some/location"})
+    def test_restage_single_fixed_config(self):
+        from restage.config import config
+        self.assertTrue(config['fixed'].exists())
+        self.assertEqual(config['fixed'].as_path(), Path('/tmp/some/location'))
+
+    @first
+    @mock.patch.dict(os.environ, {'RESTAGE_FIXED': '/tmp/a /tmp/b /tmp/c'})
+    def test_restage_multi_fixed_config(self):
+        from restage.config import config
+        self.assertTrue(config['fixed'].exists())
+        more = config['fixed'].as_str_seq()
+        self.assertEqual(len(more), 3)
+        self.assertEqual(Path(more[0]), Path('/tmp/a'))
+        self.assertEqual(Path(more[1]), Path('/tmp/b'))
+        self.assertEqual(Path(more[2]), Path('/tmp/c'))


### PR DESCRIPTION
Fixes #18 by accepting configuration variables from file or environment variables to specify the mutable cache location and any number of immutable cache locations.