### PR TITLE
[Update] mccode-antlr version, MCPL use [Fix] ENV mocking tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 *__pychache__/
 *.c
+*.instr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     'platformdirs>=3.11',
     'confuse',
     'psutil>=5.9.6',
-    'mccode-antlr[hdf5]>=0.10.2',
+    'mccode-antlr[hdf5]>=0.12.0',
 ]
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/test/test_env_vars.py
+++ b/test/test_env_vars.py
@@ -1,39 +1,29 @@
-import os
-from unittest import TestCase, mock
+from unittest import TestCase
+from unittest.mock import patch
 from pathlib import Path
-
-
-def restage_loaded():
-    import sys
-    return 'restage' in sys.modules or 'restage.config' in sys.modules
-
-
-def first(test):
-    import unittest
-    @unittest.skipIf(restage_loaded(), reason="Environment variable patching must be done before restage is loaded")
-    def first_test(*args, **kwargs):
-        return test(*args, **kwargs)
-    return first_test
+from importlib import reload
+import restage.config
 
 
 class SettingsTests(TestCase):
-    @first
-    @mock.patch.dict(os.environ, {"RESTAGE_CACHE": "/tmp/some/location"})
+    import os
+    @patch.dict(os.environ, {"RESTAGE_CACHE": "/tmp/some/location"})
     def test_restage_cache_config(self):
+        reload(restage.config)
         from restage.config import config
         self.assertTrue(config['cache'].exists())
         self.assertEqual(config['cache'].as_path(), Path('/tmp/some/location'))
 
-    @first
-    @mock.patch.dict(os.environ, {"RESTAGE_FIXED": "/tmp/some/location"})
+    @patch.dict(os.environ, {"RESTAGE_FIXED": "/tmp/some/location"})
     def test_restage_single_fixed_config(self):
+        reload(restage.config)
         from restage.config import config
         self.assertTrue(config['fixed'].exists())
         self.assertEqual(config['fixed'].as_path(), Path('/tmp/some/location'))
 
-    @first
-    @mock.patch.dict(os.environ, {'RESTAGE_FIXED': '/tmp/a /tmp/b /tmp/c'})
+    @patch.dict(os.environ, {'RESTAGE_FIXED': '/tmp/a /tmp/b /tmp/c'})
     def test_restage_multi_fixed_config(self):
+        reload(restage.config)
         from restage.config import config
         self.assertTrue(config['fixed'].exists())
         more = config['fixed'].as_str_seq()

--- a/test/test_env_vars.py
+++ b/test/test_env_vars.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 from unittest.mock import patch
-from pathlib import Path
 from importlib import reload
 import restage.config
 
@@ -12,14 +11,14 @@ class SettingsTests(TestCase):
         reload(restage.config)
         from restage.config import config
         self.assertTrue(config['cache'].exists())
-        self.assertEqual(config['cache'].as_path(), Path('/tmp/some/location'))
+        self.assertEqual(config['cache'].as_str(), '/tmp/some/location')
 
     @patch.dict(os.environ, {"RESTAGE_FIXED": "/tmp/some/location"})
     def test_restage_single_fixed_config(self):
         reload(restage.config)
         from restage.config import config
         self.assertTrue(config['fixed'].exists())
-        self.assertEqual(config['fixed'].as_path(), Path('/tmp/some/location'))
+        self.assertEqual(config['fixed'].as_str(), '/tmp/some/location')
 
     @patch.dict(os.environ, {'RESTAGE_FIXED': '/tmp/a /tmp/b /tmp/c'})
     def test_restage_multi_fixed_config(self):
@@ -28,16 +27,16 @@ class SettingsTests(TestCase):
         self.assertTrue(config['fixed'].exists())
         more = config['fixed'].as_str_seq()
         self.assertEqual(len(more), 3)
-        self.assertEqual(Path(more[0]), Path('/tmp/a'))
-        self.assertEqual(Path(more[1]), Path('/tmp/b'))
-        self.assertEqual(Path(more[2]), Path('/tmp/c'))
+        self.assertEqual(more[0],'/tmp/a')
+        self.assertEqual(more[1],'/tmp/b')
+        self.assertEqual(more[2],'/tmp/c')
 
     def test_restage_standard_config(self):
         from os import environ
         reload(restage.config)
         from restage.config import config
         if 'cache' in config:
-            self.assertEqual(config['cache'].as_path(), Path(environ['RESTAGE_CACHE']))
+            self.assertEqual(config['cache'].as_str(), environ['RESTAGE_CACHE'])
         if 'fixed' in config:
             self.assertEqual(config['fixed'].as_str(), environ['RESTAGE_FIXED'])
 

--- a/test/test_env_vars.py
+++ b/test/test_env_vars.py
@@ -31,3 +31,13 @@ class SettingsTests(TestCase):
         self.assertEqual(Path(more[0]), Path('/tmp/a'))
         self.assertEqual(Path(more[1]), Path('/tmp/b'))
         self.assertEqual(Path(more[2]), Path('/tmp/c'))
+
+    def test_restage_standard_config(self):
+        from os import environ
+        reload(restage.config)
+        from restage.config import config
+        if 'cache' in config:
+            self.assertEqual(config['cache'].as_path(), Path(environ['RESTAGE_CACHE']))
+        if 'fixed' in config:
+            self.assertEqual(config['fixed'].as_str(), environ['RESTAGE_FIXED'])
+


### PR DESCRIPTION
- `mccode-antlr` has been updated to `v0.12.0` with some CLI changes and to support the latest McCode grammar
- `MCPL` `v2.2` and `MCPL_ouput.comp` + `MCPL_input_once.comp` now support cumulative statistics, but require a component flag to turn on the behavior (`weight_mode=1` for `MCPL_output`, all others detect the mode automatically)
- `MCPL_input_once.comp` has been accepted into the `McCode` repository, so does not need an extra registry entry
- Environment variable `RESTAGE_CACHE` and `RESTAGE_FIXED` testing has been fixed to work even if not run first by reloading the `restage.cache` submodule