### PR TITLE
Update `mccode-antlr` version, smaller default parameter matching precision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     'platformdirs>=3.11',
     'confuse',
     'psutil>=5.9.6',
-    'mccode-antlr[hdf5]>=0.13.0',
+    'mccode-antlr[hdf5]>=0.14.0',
 ]
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/src/restage/tables.py
+++ b/src/restage/tables.py
@@ -65,7 +65,7 @@ class SimulationEntry:
                     self.precision[k] = abs(self.precision[best[0]])
                 elif self.parameter_values[k].has_value:
                     # This abs is *crucial* since a negative parameter value would have a negative precision otherwise
-                    self.precision[k] = abs(self.parameter_values[k].value / 100)
+                    self.precision[k] = abs(self.parameter_values[k].value / 10000)
                 else:
                     log.info(f'SimulationEntry.__post_init__:: No precision match for value-less {k}, using 0.1;'
                              ' consider specifying precision dict during initialization')

--- a/test/test_single.py
+++ b/test/test_single.py
@@ -148,12 +148,7 @@ class SplitRunTestCase(unittest.TestCase):
 
     def _define_instr(self):
         from math import pi, asin, sqrt
-        from mccode_antlr.reader import MCSTAS_REGISTRY
-        from mccode_antlr.loader.loader import parse_mccode_instr
-
-        def parse(contents):
-            registries = [MCSTAS_REGISTRY]
-            return parse_mccode_instr(contents, registries, '<test string>')
+        from mccode_antlr.loader.loader import parse_mcstas_instr
 
         d_spacing = 3.355  # (002) for Highly-ordered Pyrolytic Graphite
         mean_energy = 5.0
@@ -193,7 +188,7 @@ class SplitRunTestCase(unittest.TestCase):
         COMPONENT detector = Monitor(xwidth=0.01, yheight=0.05) AT (0, 0, 0.8) RELATIVE sample_arm
         END
         """
-        return parse(instr), min_a1, max_a1
+        return parse_mcstas_instr(instr), min_a1, max_a1
 
     def setUp(self) -> None:
         from pathlib import Path


### PR DESCRIPTION
Fixes #26, and trials a solution for #17 