### PR TITLE
[Add] check for config['fixed'].get() is None to avoid a type error for empty ${RESTAGE_FIXED}

### DIFF
--- a/src/restage/cache.py
+++ b/src/restage/cache.py
@@ -26,7 +26,7 @@ class FileSystem:
                 path.mkdir(parents=True)
             db_write = Database(path / named)
             root = path
-        if config['fixed'].exists():
+        if config['fixed'].exists() and config['fixed'].get() is not None:
             more = [Path(c) for c in config['fixed'].as_str_seq() if Path(c).exists()]
             for m in more:
                 db_fixed.append(Database(m / named, readonly=True))

--- a/test/test_env_vars.py
+++ b/test/test_env_vars.py
@@ -31,6 +31,15 @@ class SettingsTests(TestCase):
         self.assertEqual(more[1],'/tmp/b')
         self.assertEqual(more[2],'/tmp/c')
 
+    @patch.dict(os.environ, {"RESTAGE_FIXED": ''})
+    def test_restage_none_fixed_config(self):
+        reload(restage.config)
+        from restage.config import config
+        from confuse.exceptions import ConfigTypeError
+        self.assertTrue(config['fixed'].exists())
+        self.assertTrue(config['fixed'].get() is None)
+        self.assertRaises(ConfigTypeError, config['fixed'].as_str_seq)
+
     def test_restage_standard_config(self):
         from os import environ
         reload(restage.config)


### PR DESCRIPTION
Fixes #28 by verifying that the retrieved configuration value is not None before trying to use `as_str_seq` to produce a list of strings.