### PR TITLE
[Rem] unhelpful debugging MCPL message

### DIFF
--- a/src/restage/mcpl.py
+++ b/src/restage/mcpl.py
@@ -15,7 +15,6 @@ def mcpl_real_filename(filename: Path) -> Path:
         check = base.with_suffix(ext)
         if check.exists() and check.is_file():
             return check
-        print(f'{base} -> {check} not found')
     raise FileNotFoundError(f'Could not find MCPL file {filename}')
 
 


### PR DESCRIPTION
The `mcpl_real_filename` command seems to work as expected, there's no need to inform a user that expected 'not found' files were encountered.