### PR TITLE
[Update] mccode-antlr v0.19.0 and related minor fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     'platformdirs>=3.11',
     'confuse',
     'psutil>=5.9.6',
-    'mccode-antlr[hdf5]>=0.18.4',
+    'mccode-antlr[hdf5]>=0.19.0',
 ]
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/src/restage/instr.py
+++ b/src/restage/instr.py
@@ -34,25 +34,25 @@ def collect_parameter_dict(instr: Instr, kwargs: dict, strict: bool = True) -> d
     :param strict: if True, raises an error if a parameter is specified in kwargs that is not in instr
     :return: dict of parameters from instr and kwargs
     """
-    from mccode_antlr.common.expression import Value
+    from mccode_antlr.common.expression import Expr
     parameters = {p.name: p.value for p in instr.parameters}
     for k, v in parameters.items():
+        if not isinstance(v, Expr):
+            raise ValueError(f"Parameter {k} is not a valid parameter name")
         if not v.is_singular:
             raise ValueError(f"Parameter {k} is not singular, and cannot be set")
         if v.is_op:
             raise ValueError(f"Parameter {k} is an operation, and cannot be set")
-        if not isinstance(v.first, Value):
-            raise ValueError(f"Parameter {k} is not a valid parameter name")
-        parameters[k] = v.first
+        parameters[k] = v
 
     for k, v in kwargs.items():
         if k not in parameters:
             if strict:
                 raise ValueError(f"Parameter {k} is not a valid parameter name. Valid names are: {', '.join(parameters)}")
             continue
-        if not isinstance(v, Value):
+        if not isinstance(v, Expr):
             expected_type = parameters[k].data_type
-            v = Value(v, expected_type)
+            v = Expr(v, expected_type)
         parameters[k] = v
 
     return parameters

--- a/src/restage/tables.py
+++ b/src/restage/tables.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from mccode_antlr.common import Value
+from mccode_antlr.common import Expr
 
 
 def uuid():
@@ -25,7 +25,7 @@ COMMON_COLUMNS = ['seed', 'ncount', 'output_path', 'gravitation', 'creation', 'l
 @dataclass
 class SimulationEntry:
     """A class to represent the primary parameters of a simulation which constitute an entry in a specific table"""
-    parameter_values: dict[str, Value]
+    parameter_values: dict[str, Expr]
     seed: int | None = None
     ncount: int | None = None
     output_path: str = field(default_factory=str)
@@ -51,8 +51,8 @@ class SimulationEntry:
     def __post_init__(self):
         from zenlog import log
         for k, v in self.parameter_values.items():
-            if not isinstance(v, Value):
-                self.parameter_values[k] = Value.best(v)
+            if not isinstance(v, Expr):
+                self.parameter_values[k] = Expr.best(v)
 
         for k, v in self.parameter_values.items():
             if v.is_float and k not in self.precision:

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -74,7 +74,7 @@ class MyTestCase(unittest.TestCase):
 
     def test_simulation(self):
         from restage import SimulationTableEntry, SimulationEntry
-        from mccode_antlr.common import Value
+        from mccode_antlr.common import Expr
         name = 'super_instr_2'
         parameters = ['par1', 'par2', 'par3', 'par4']
         entry = SimulationTableEntry(parameters=parameters, name=name)
@@ -90,7 +90,7 @@ class MyTestCase(unittest.TestCase):
         entry = res[0]
 
         simulation_pars = {'par1': 1.1, 'par2': 2.2, 'par3': 3.3, 'par4': 4.4}
-        simulation_pars = {k: Value.best(v) for k, v in simulation_pars.items()}
+        simulation_pars = {k: Expr.best(v) for k, v in simulation_pars.items()}
         # we did the 'same' simulation three times, but with different seeds and ncounts
         first_simulation = SimulationEntry(parameter_values=simulation_pars)
         self.db.insert_simulation(entry, first_simulation)


### PR DESCRIPTION
This pull request updates the codebase to consistently use the `Expr` class from `mccode_antlr.common` instead of the older `Value` class for representing parameter values. This affects both the main code and the tests, and ensures stricter type checking and compatibility with the updated dependency.

Dependency update:

* Upgraded `mccode-antlr[hdf5]` dependency from version `0.18.4` to `0.19.0` in `pyproject.toml`, which requires the use of `Expr` as `Value` has been removed.

Migration from `Value` to `Expr`:

* Replaced all imports and usages of `Value` with `Expr` in `src/restage/tables.py`, including the `parameter_values` type in `SimulationEntry` and the logic in `__post_init__` to ensure all values are `Expr` instances. [[1]](diffhunk://#diff-891b687c921acbcf575bbc6aec9d89672d79e527e5fe24abd6c382465644a57cL4-R4) [[2]](diffhunk://#diff-891b687c921acbcf575bbc6aec9d89672d79e527e5fe24abd6c382465644a57cL28-R28) [[3]](diffhunk://#diff-891b687c921acbcf575bbc6aec9d89672d79e527e5fe24abd6c382465644a57cL54-R55)
* Updated the test code in `test/test_database.py` to use `Expr.best()` instead of `Value.best()` for creating simulation parameters, ensuring tests align with the new type. [[1]](diffhunk://#diff-5e39a56c260553d0e85d54ca8742a388aef27003a3755d7f1ccae5b1a9e90882L77-R77) [[2]](diffhunk://#diff-5e39a56c260553d0e85d54ca8742a388aef27003a3755d7f1ccae5b1a9e90882L93-R93)

Parameter handling improvements:

* Updated `collect_parameter_dict` in `src/restage/instr.py` to use `Expr` for type checking and instantiation, and added stricter validation to ensure all parameters are valid `Expr` instances.