### PR TITLE
Update mccode-antlr to v0.21.0 and remove HDF5 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     'platformdirs>=3.11',
     'confuse',
     'psutil>=5.9.6',
-    'mccode-antlr[hdf5]>=0.20.1',
+    'mccode-antlr>=0.21.0',
     'sqlmodel>=0.0.18',
     'tqdm>=4.0',
 ]


### PR DESCRIPTION
This pull request updates a dependency version in the `pyproject.toml` file. The `mccode-antlr` package is upgraded to version 0.21.0 and the optional `[hdf5]` extra is removed.